### PR TITLE
change font color in a Pill to a more contrasting one

### DIFF
--- a/frontend/src/components/Pill/Pill.module.scss
+++ b/frontend/src/components/Pill/Pill.module.scss
@@ -9,7 +9,7 @@
   min-width: fit-content;
   width: 175px !important;
   border-radius: 45px;
-  color: white;
+  color: #023e8a;
   margin: auto;
   height: 50px;
   &.blue {


### PR DESCRIPTION
Change the font color in a Pill to a more contrasting one, also for consistency and similarity (exactly the same font color) to what was done previously in Soon Expiring.

<img width="650" alt="more contrasting font in a Pill" src="https://user-images.githubusercontent.com/18016669/157911828-8666ae48-baa4-4aae-9d06-65fd8aa7ead0.png">

